### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Suggests:
     doMC,
     testthat,
     covr,
-    vdiffr,
     knitr,
     rmarkdown
 License: MIT + file LICENSE


### PR DESCRIPTION
vdiffr causes installation errors on HYDRA. Removing it from suggests. not needed